### PR TITLE
Added optional (configurable) watch interval to reduce CPU load on large repositories

### DIFF
--- a/components/redcore.js
+++ b/components/redcore.js
@@ -10,6 +10,11 @@ catch(err) {
 	var config = require('../../../gulp-config.json');
 }
 
+var watchInterval = 500;
+if (typeof config.watchInterval !== 'undefined') {
+	watchInterval = config.watchInterval;
+}
+
 // Dependencies
 var browserSync = require('browser-sync');
 var del         = require('del');
@@ -82,6 +87,7 @@ gulp.task('watch:' + baseTask,
 // Watch cli
 gulp.task('watch:' + baseTask + ':cli', function() {
 	gulp.watch(extPath + '/cli/**/*',
+	{ interval: watchInterval },
 	['copy:' + baseTask + ':cli', browserSync.reload]);
 });
 
@@ -92,5 +98,6 @@ gulp.task('watch:' + baseTask + ':backend', function() {
 		extPath + '/../redcore.xml',
 		extPath + '/../install.php'
 	],
+	{ interval: watchInterval },
 	['copy:' + baseTask + ':backend', browserSync.reload]);
 });

--- a/libraries/redcore.js
+++ b/libraries/redcore.js
@@ -10,6 +10,11 @@ catch(err) {
 	var config = require('../../../gulp-config.json');
 }
 
+var watchInterval = 500;
+if (typeof config.watchInterval !== 'undefined') {
+	watchInterval = config.watchInterval;
+}
+
 // Dependencies
 var browserSync = require('browser-sync');
 var del         = require('del');
@@ -83,15 +88,21 @@ gulp.task('watch:' +  baseTask + ':library', function() {
 	gulp.watch([
 			extPath + '/**/*',
 			'!' + extPath + '/redcore.xml'
-		], ['copy:' + baseTask + ':library', browserSync.reload]);
+		],
+		{ interval: watchInterval },
+		['copy:' + baseTask + ':library', browserSync.reload]);
 });
 
 // Watch: languages
 gulp.task('watch:' +  baseTask + ':languages', function() {
-	gulp.watch(extPath + '/language/**/*', ['copy:' + baseTask + ':languages', browserSync.reload]);
+	gulp.watch(extPath + '/language/**/*',
+	{ interval: watchInterval },
+	['copy:' + baseTask + ':languages', browserSync.reload]);
 });
 
 // Watch: manifest
 gulp.task('watch:' +  baseTask + ':manifest', function() {
-	gulp.watch(extPath + '/redcore.xml', ['copy:' + baseTask + ':manifest', browserSync.reload]);
+	gulp.watch(extPath + '/redcore.xml',
+	{ interval: watchInterval },
+	['copy:' + baseTask + ':manifest', browserSync.reload]);
 });

--- a/media/redcore.js
+++ b/media/redcore.js
@@ -9,6 +9,11 @@ catch(err) {
 	var config = require('../../../gulp-config.json');
 }
 
+var watchInterval = 500;
+if (typeof config.watchInterval !== 'undefined') {
+	watchInterval = config.watchInterval;
+}
+
 // Dependencies
 var browserSync = require('browser-sync');
 var del         = require('del');
@@ -151,6 +156,7 @@ gulp.task('watch:' + baseTask + ':less',
 	function() {
 		gulp.watch(
 			[extPath + '/less/**/*.less'],
+			{ interval: watchInterval },
 			['less:' + baseTask, browserSync.reload]
 		);
 });
@@ -163,6 +169,7 @@ gulp.task('watch:' + baseTask + ':scripts',
 			'!' + extPath + '/js/lib/**',
 			'!' + extPath + '/js/**/*.min.js'
 		],
+		{ interval: watchInterval },
 		['scripts:' + baseTask, browserSync.reload]);
 });
 
@@ -174,6 +181,7 @@ gulp.task('watch:' + baseTask + ':styles',
 			'!' + extPath + '/css/lib/**',
 			'!' + extPath + '/css/*.min.css'
 		],
+		{ interval: watchInterval },
 		['styles:' + baseTask, browserSync.reload]);
 });
 
@@ -181,6 +189,7 @@ gulp.task('watch:' + baseTask + ':styles',
 gulp.task('watch:' + baseTask + ':translations',
 	function() {
 		gulp.watch([extPath + '/translations/**/*.xml'],
+		{ interval: watchInterval },
 		['copy:' + baseTask + ':translations', browserSync.reload]);
 });
 
@@ -188,5 +197,6 @@ gulp.task('watch:' + baseTask + ':translations',
 gulp.task('watch:' + baseTask + ':webservices',
 	function() {
 		gulp.watch([extPath + '/webservices/**/*'],
+		{ interval: watchInterval },
 		['copy:' + baseTask + ':webservices', browserSync.reload]);
 });

--- a/modules/site/redcore_langswitcher.js
+++ b/modules/site/redcore_langswitcher.js
@@ -9,6 +9,11 @@ catch(err) {
 	var config = require('../../../../gulp-config.json');
 }
 
+var watchInterval = 500;
+if (typeof config.watchInterval !== 'undefined') {
+	watchInterval = config.watchInterval;
+}
+
 // Dependencies
 var browserSync = require('browser-sync');
 var minifyCSS   = require('gulp-minify-css');
@@ -83,7 +88,9 @@ gulp.task('watch:' + baseTask + ':module', function() {
     	extPath + '/**/*',
     	'!' + mediaPath + '/css',
     	'!' + mediaPath + '/css/**'
-    ], ['copy:' + baseTask, browserSync.reload]);
+    ],
+		{ interval: watchInterval },
+		['copy:' + baseTask, browserSync.reload]);
 });
 
 // Watch: Styles
@@ -91,5 +98,7 @@ gulp.task('watch:' + baseTask + ':styles', function() {
     gulp.watch([
     	mediaPath + '/css/*.css',
     	'!' + mediaPath + '/css/*.min.css'
-    ], ['styles:' + baseTask, browserSync.reload]);
+    ],
+		{ interval: watchInterval },
+		['styles:' + baseTask, browserSync.reload]);
 });

--- a/plugins/redpayment/paypal.js
+++ b/plugins/redpayment/paypal.js
@@ -9,6 +9,11 @@ catch(err) {
 	var config = require('../../../../gulp-config.json');
 }
 
+var watchInterval = 500;
+if (typeof config.watchInterval !== 'undefined') {
+	watchInterval = config.watchInterval;
+}
+
 // Dependencies
 var browserSync = require('browser-sync');
 var del         = require('del');
@@ -41,5 +46,7 @@ gulp.task('watch:' + baseTask,
 
 // Watch: plugin
 gulp.task('watch:' + baseTask + ':plugin', function() {
-	gulp.watch(extPath + '/**/*', ['copy:' + baseTask, browserSync.reload]);
+	gulp.watch(extPath + '/**/*',
+	{ interval: watchInterval },
+	['copy:' + baseTask, browserSync.reload]);
 });

--- a/plugins/system/mvcoverride.js
+++ b/plugins/system/mvcoverride.js
@@ -9,6 +9,11 @@ catch(err) {
 	var config = require('../../../../gulp-config.json');
 }
 
+var watchInterval = 500;
+if (typeof config.watchInterval !== 'undefined') {
+	watchInterval = config.watchInterval;
+}
+
 // Dependencies
 var browserSync = require('browser-sync');
 var del         = require('del');
@@ -41,5 +46,7 @@ gulp.task('watch:' + baseTask,
 
 // Watch: plugin
 gulp.task('watch:' + baseTask + ':plugin', function() {
-	gulp.watch(extPath + '/**/*', ['copy:' + baseTask, browserSync.reload]);
+	gulp.watch(extPath + '/**/*',
+	{ interval: watchInterval },
+	['copy:' + baseTask, browserSync.reload]);
 });

--- a/plugins/system/redcore.js
+++ b/plugins/system/redcore.js
@@ -9,6 +9,11 @@ catch(err) {
 	var config = require('../../../../gulp-config.json');
 }
 
+var watchInterval = 500;
+if (typeof config.watchInterval !== 'undefined') {
+	watchInterval = config.watchInterval;
+}
+
 // Dependencies
 var browserSync = require('browser-sync');
 var del         = require('del');
@@ -41,5 +46,7 @@ gulp.task('watch:' + baseTask,
 
 // Watch: plugin
 gulp.task('watch:' + baseTask + ':plugin', function() {
-	gulp.watch(extPath + '/**/*', ['copy:' + baseTask, browserSync.reload]);
+	gulp.watch(extPath + '/**/*',
+	{ interval: watchInterval },
+	['copy:' + baseTask, browserSync.reload]);
 });


### PR DESCRIPTION
On large repositories (like redSHOP B2B) CPU load is very high because of the number of files gulp has to watch.

This change allows a new (optional) configuration to be stored under `gulp-config.json` file, so the default poll time (100ms) for watch task can be overridden:

``` json
"watchInterval" : "500"
```
